### PR TITLE
bpq32.cfg: Set SECURETELNET on Telnet port

### DIFF
--- a/debian/bpq32.cfg
+++ b/debian/bpq32.cfg
@@ -34,6 +34,7 @@ PORT
     LOGGING=1
     CMS=1
     DisconnectOnClose=1
+    SECURETELNET=1
     TCPPORT=8010
     FBBPORT=8011
     HTTPPORT=8008


### PR DESCRIPTION
The SECURETELNET option restricts outbound telnet connections from the node to users who have authenticated.